### PR TITLE
refactor: consistent use of ESM imports

### DIFF
--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -15,6 +15,8 @@
 
 // Import commands.js using ES2015 syntax:
 import './commands'
-require('cypress-terminal-report/src/installLogsCollector')();
+import installLogsCollector from 'cypress-terminal-report/src/installLogsCollector'
+
+installLogsCollector()
 // Alternatively you can use CommonJS syntax:
 // require('./commands')


### PR DESCRIPTION
The printer is already imported using `import` in `cypress.config.ts`. This changes the usage in the `support/e2e.ts` to match this behaviour

Many projects have linting rules that forbid the use of CommonJS `require` in JavaScript and TypeScript files